### PR TITLE
Making DES functions generic

### DIFF
--- a/des/des.cpp
+++ b/des/des.cpp
@@ -20,7 +20,7 @@ void DES::to_binary(const std::string &str, std::bitset<1> *data)
     }
 }
 
-void DES::permute_pc1()
+void DES::permute_pc1(std::bitset<1> *perm_key, const std::bitset<1> *k_data)
 {
     for(int i = 0; i < 56; i++)
     {
@@ -47,7 +47,7 @@ void DES::ip_message()
     }
 }
 
-void DES::split_key()
+void DES::split_key(std::bitset<1> *left_half_key, std::bitset<1> *right_half_key, std::bitset<1> *perm_key)
 {      
     for(size_t i = 0; i < 28; i++)
     {
@@ -65,7 +65,7 @@ void DES::split_message()
     }
 }
 
-void DES::rotate(int n)
+void DES::rotate(int n, std::bitset<1> *left_half_key, std::bitset<1> *right_half_key)
 {
     std::bitset<1> temp_right[28];
     std::bitset<1> temp_left[28];
@@ -94,13 +94,18 @@ void DES::rotate(int n)
 
 void DES::generate_keys(const std::string &key)
 {
+    std::bitset<1> k_data[64];
+    std::bitset<1> perm_key[56];
+    std::bitset<1> left_half_key[28];
+    std::bitset<1> right_half_key[28];
+
     to_binary(key, k_data);
-    permute_pc1();
-    split_key();
+    permute_pc1(perm_key, k_data);
+    split_key(left_half_key, right_half_key, perm_key);
 
     for(size_t i = 0; i < 16; i++)
     {
-        rotate(no_shifts[i]);
+        rotate(no_shifts[i], left_half_key, right_half_key);
 
         for(size_t j = 0; j < 56; j++)
         {   

--- a/des/des.h
+++ b/des/des.h
@@ -16,9 +16,6 @@ private:
     std::bitset<4> cipher_message[16];
     std::bitset<4> plain_message[16];
 
-protected:
-    uint8_t no_shifts[16] = {1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1};
-
 public:
     void generate_keys(const std::string &key);
     void encrypt(std::string &message);
@@ -40,6 +37,9 @@ private:
     void get_message(std::bitset<4> *m, std::bitset<1> *perm_m);
     void bits2string(std::string &message, std::bitset<4> *bits);
 
+protected:
+    uint8_t no_shifts[16] = {1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1};
+    
     const uint8_t pc_1[56] = { 57, 49, 41, 33, 25, 17, 9,
                                 1, 58, 50, 42, 34, 26, 18,
                                 10, 2, 59, 51, 43, 35, 27,

--- a/des/des.h
+++ b/des/des.h
@@ -7,39 +7,38 @@
 class DES
 {
 private:
-    std::bitset<1> k_data[64];
     std::bitset<1> m_data[64];
     std::bitset<1> perm_message[64];
     std::bitset<1> right_half_message[32];
     std::bitset<1> left_half_message[32];
-    std::bitset<1> perm_key[56];
-    std::bitset<1> right_half_key[28];
-    std::bitset<1> left_half_key[28];
     std::bitset<1> subkeys[16][56];
     std::bitset<1> perm_subkeys[16][48];
     std::bitset<4> cipher_message[16];
     std::bitset<4> plain_message[16];
+
+protected:
+    uint8_t no_shifts[16] = {1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1};
 
 public:
     void generate_keys(const std::string &key);
     void encrypt(std::string &message);
     void decrypt(std::string &cipher);
 
-private:
+protected:
     void to_binary(const std::string &str, std::bitset<1> *data);
-    void permute_pc1();
+    void permute_pc1(std::bitset<1> *perm_key, const std::bitset<1> *k_data);
     void permute_pc2();
+    void split_key(std::bitset<1> *left_half_key, std::bitset<1> *right_half_key, std::bitset<1> *perm_key);
+    void rotate(int n, std::bitset<1> *left_half_key, std::bitset<1> *right_half_key);
+
+private:
     void ip_message();
-    void split_key();
     void split_message();
-    void rotate(int n);
     void round_op(int i);
     void concat_halves(std::bitset<1> *concat_m);
     void final_permutation(std::bitset<1> *perm_m, std::bitset<1> *m);
     void get_message(std::bitset<4> *m, std::bitset<1> *perm_m);
     void bits2string(std::string &message, std::bitset<4> *bits);
-
-    uint8_t no_shifts[16] = {1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1};
 
     const uint8_t pc_1[56] = { 57, 49, 41, 33, 25, 17, 9,
                                 1, 58, 50, 42, 34, 26, 18,

--- a/des/des.h
+++ b/des/des.h
@@ -7,14 +7,8 @@
 class DES
 {
 private:
-    std::bitset<1> m_data[64];
-    std::bitset<1> perm_message[64];
-    std::bitset<1> right_half_message[32];
-    std::bitset<1> left_half_message[32];
     std::bitset<1> subkeys[16][56];
     std::bitset<1> perm_subkeys[16][48];
-    std::bitset<4> cipher_message[16];
-    std::bitset<4> plain_message[16];
 
 public:
     void generate_keys(const std::string &key);
@@ -25,17 +19,17 @@ protected:
     void to_binary(const std::string &str, std::bitset<1> *data);
     void permute_pc1(std::bitset<1> *perm_key, const std::bitset<1> *k_data);
     void permute_pc2();
-    void split_key(std::bitset<1> *left_half_key, std::bitset<1> *right_half_key, std::bitset<1> *perm_key);
+    void split_key(std::bitset<1> *left_half_key, std::bitset<1> *right_half_key, const std::bitset<1> *perm_key);
     void rotate(int n, std::bitset<1> *left_half_key, std::bitset<1> *right_half_key);
 
 private:
-    void ip_message();
-    void split_message();
-    void round_op(int i);
-    void concat_halves(std::bitset<1> *concat_m);
-    void final_permutation(std::bitset<1> *perm_m, std::bitset<1> *m);
-    void get_message(std::bitset<4> *m, std::bitset<1> *perm_m);
-    void bits2string(std::string &message, std::bitset<4> *bits);
+    void ip_message(std::bitset<1> *perm_message, const std::bitset<1> *m_data);
+    void split_message(std::bitset<1> *left_half_message, std::bitset<1> *right_half_message, const std::bitset<1> *perm_message);
+    void round_op(int i, std::bitset<1> *left_half_message, std::bitset<1> *right_half_message);
+    void concat_halves(std::bitset<1> *concat_m, const std::bitset<1> *left_half_message, const std::bitset<1> *right_half_message);
+    void final_permutation(std::bitset<1> *perm_m, const std::bitset<1> *m);
+    void get_message(std::bitset<4> *m, const std::bitset<1> *perm_m);
+    void bits2string(std::string &message, const std::bitset<4> *bits);
 
 protected:
     uint8_t no_shifts[16] = {1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1};


### PR DESCRIPTION
Making DES functions generic involves changing the implementation of key generation/ message handling functions to accept function parameters instead of operating on fields. The aim is to make functions more generic.